### PR TITLE
minor fixes for macOS

### DIFF
--- a/Source/UE_Assimp/Private/AIScene.cpp
+++ b/Source/UE_Assimp/Private/AIScene.cpp
@@ -191,12 +191,12 @@ UTexture2D* UAIScene::GetEmbeddedTexture(FString FilePath, bool bIsNormalMap)
 				}
 			}
 			FMemory::Memcpy(MipData, Pixels, PlatformData->Mips[0].BulkData.GetBulkDataSize());
+
+
+		        PlatformData->Mips[0].BulkData.Unlock();
+
+		        Result->UpdateResource();
 		}
-
-
-		Result->PlatformData->Mips[0].BulkData.Unlock();
-
-		Result->UpdateResource();
 	}
 	else
 	{

--- a/Source/UE_Assimp/Public/UE_Assimp.h
+++ b/Source/UE_Assimp/Public/UE_Assimp.h
@@ -73,15 +73,15 @@ public:
 UENUM(Blueprintable,BlueprintType)
  enum EAssimpReturn {
 	/** Indicates that a function was successful */
-	ReturnSuccess = 0x0,
+	ReturnSuccess = 0,
 
     /** Indicates that a function failed */
-  ReturnFail = -0x1,
+  ReturnFail = -1,
 
     /** Indicates that not enough memory was available
     * to perform the requested operation
     */
-    ReturnOutOfMemory = -0x3,
+    ReturnOutOfMemory = -3,
 
 
 


### PR DESCRIPTION
There were a few negative hex values that macOS prefers to see as ints.
Also, there was a small scope-related bug.