### PR TITLE
Fixes for 5.1 "red nodes of death"

### DIFF
--- a/Source/ThirdParty/UE_AssimpLibrary/UE_AssimpLibrary.Build.cs
+++ b/Source/ThirdParty/UE_AssimpLibrary/UE_AssimpLibrary.Build.cs
@@ -69,7 +69,6 @@ public class UE_AssimpLibrary : ModuleRules
         else if (Target.Platform == UnrealTargetPlatform.Android)
         {
 			PublicAdditionalLibraries.Add(Path.Combine(BinaryFolder, "arm64-v8a", "libassimp.so"));
-		}
 	}
 	else if (Target.Platform == UnrealTargetPlatform.Linux)
         {
@@ -81,6 +80,7 @@ public class UE_AssimpLibrary : ModuleRules
 			string BinPath = Path.Combine(ModuleDirectory, BinaryFolder, "libassimp.so");
 			
 		 	CopyFile(AssimpSo,BinPath);
+        }
         }
 	
 	public void CopyFile(string Source, string Dest)

--- a/Source/UE_Assimp/Private/AIMaterial.cpp
+++ b/Source/UE_Assimp/Private/AIMaterial.cpp
@@ -17,7 +17,7 @@ void UAIMaterial::GetMaterialBaseColor(FLinearColor& BaseColor) const
 	aiColor3D color;
 	if (AI_SUCCESS == Material->Get(AI_MATKEY_COLOR_DIFFUSE, color))
 	{
-		BaseColor = FColor((color.r*100.f), (color.g*100.f), (color.b*100.f), 1.0f);
+		BaseColor = FLinearColor(color.r, color.g, color.b, 1.0f);
 	}
 }
 

--- a/Source/UE_Assimp/Private/AINode.cpp
+++ b/Source/UE_Assimp/Private/AINode.cpp
@@ -66,7 +66,7 @@ FTransform UAINode::GetRootTransform()
 	return WorldTransform;
 }
 
-bool UAINode::GetAllMeshes(TArray<UAIMesh*>& Meshes)
+bool UAINode::GetNodeMeshes(TArray<UAIMesh*>& Meshes)
 {
 	UAIScene* Scene = GetScene();
 	if (Scene)

--- a/Source/UE_Assimp/Public/AINode.h
+++ b/Source/UE_Assimp/Public/AINode.h
@@ -64,7 +64,7 @@ public:
 	FTransform GetRootTransform();
 	//false if empty
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category="Assimp|Node")
-	bool GetAllMeshes(TArray<UAIMesh*>& Meshes);
+	bool GetNodeMeshes(TArray<UAIMesh*>& Meshes);
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category="Assimp|Node")
 	UAIScene* GetScene();
 

--- a/UE_Assimp.uplugin
+++ b/UE_Assimp.uplugin
@@ -13,12 +13,12 @@
 	"CanContainContent": true,
 	"IsBetaVersion": false,
 	"IsExperimentalVersion": false,
-	"Installed": false,
+    "EnabledByDefault": true,
 	"Modules": [
 		{
 			"Name": "UE_Assimp",
 			"Type": "Runtime",
-			"LoadingPhase": "Default"
+			"LoadingPhase": "PreDefault"
 		}
 	],
         "Plugins": [


### PR DESCRIPTION
On 5.1, the nodes would read into a file red and refreshing nodes did not work.
Changing the loading to "PreDefault" rather than "Default" seems to do the trick.
(Also fixed a braces placement issue which was needed for the linux section.)