### PR TITLE
Substantial change to be a more 1:1 import of Assimp data.

### DIFF
--- a/Source/UE_Assimp/Private/AICamera.cpp
+++ b/Source/UE_Assimp/Private/AICamera.cpp
@@ -34,7 +34,7 @@ float UAICamera::GetAspectRatio()
 
 FVector UAICamera::GetPosition()
 {
-	return ToVectorCM( camera->mPosition);
+	return ToVector( camera->mPosition);
 }
 
 FVector UAICamera::GetUpVector()

--- a/Source/UE_Assimp/Private/AILight.cpp
+++ b/Source/UE_Assimp/Private/AILight.cpp
@@ -75,5 +75,5 @@ float UAILight::GetConeOuterAngle()
 
 FVector2D UAILight::GetAreaLightSize()
 {
-	return FVector2D( Light->mSize.x*100.f,Light->mSize.y*100.f);
+	return FVector2D( Light->mSize.x,Light->mSize.y);
 }

--- a/Source/UE_Assimp/Private/AILight.cpp
+++ b/Source/UE_Assimp/Private/AILight.cpp
@@ -20,7 +20,7 @@ TEnumAsByte<EAssimpLightType> UAILight::GetLightType()
 
 FVector UAILight::GetLightPosition()
 {
-	return ToVectorCM(Light->mPosition);
+	return ToVector(Light->mPosition);
 }
 
 FVector UAILight::GetLightDirection()

--- a/Source/UE_Assimp/Private/AIMesh.cpp
+++ b/Source/UE_Assimp/Private/AIMesh.cpp
@@ -87,7 +87,7 @@ void UAIMesh::GetMeshDataForProceduralMesh(TArray<FVector>& Vertices, TArray<int
 	for (unsigned int Index = 0; Index < Mesh->mNumVertices; Index++)
 	{
 		Normals[Index] = ToVector(Mesh->mNormals[Index]);
-		Vertices[Index] = ToVectorCM(Mesh->mVertices[Index]);
+		Vertices[Index] = ToVector(Mesh->mVertices[Index]);
 
 		if (Mesh->mTangents)
 		{
@@ -129,7 +129,7 @@ UStaticMesh* UAIMesh::GetStaticMesh()
 	VertexInstances.AddUninitialized(Mesh->mNumVertices);
 	for (unsigned int Index = 0; Index < Mesh->mNumVertices; Index++)
 	{
-		auto VertexID = MeshDescBuilder.AppendVertex(ToVectorCM(Mesh->mVertices[Index]));
+		auto VertexID = MeshDescBuilder.AppendVertex(ToVector(Mesh->mVertices[Index]));
 
 		auto Instance = MeshDescBuilder.AppendInstance(VertexID);
 		VertexInstances[Index] = Instance;

--- a/Source/UE_Assimp/Private/AINode.cpp
+++ b/Source/UE_Assimp/Private/AINode.cpp
@@ -16,28 +16,14 @@ void UAINode::Setup(aiNode* InNode, UAIScene* Scene, const aiMatrix4x4& ParentTr
 {
 	this->Node = InNode;
 
-	
-
 	const aiMatrix4x4t<float> MyTransform = ParentTransform * Node->mTransformation;
-
-	for (unsigned Index = 0; Index < Node->mNumMeshes; Index++)
-	{
-	
-		UAIMesh* NewMeshData = NewObject<UAIMesh>(Scene, UAIMesh::StaticClass(), NAME_None, RF_Transient);
-		NewMeshData->Mesh = Scene->scene->mMeshes[Node->mMeshes[Index]];
-		WorldTransform = UAssimpFunctionLibrary::aiMatToTransform(MyTransform);
-		if (Scene->SceneScale != 0)
-		{
-			WorldTransform.SetScale3D(WorldTransform.GetScale3D() * Scene->SceneScale);
-		}
-	
-		Scene->OwnedMeshes[Node->mMeshes[Index]] = NewMeshData;
-		
-	}
+	WorldTransform = UAssimpFunctionLibrary::aiMatToTransform(MyTransform);
 
 	for (unsigned Index = 0; Index < Node->mNumChildren; Index++)
 	{
-		RegisterNewNode(Node->mChildren[Index], Scene, MyTransform);
+	        UAINode* KidNode = NewObject<UAINode>(this, UAINode::StaticClass(), NAME_None, RF_Transient);
+	        KidNode->Setup(Node->mChildren[Index], Scene, MyTransform);
+	        OwnedNodes.Add(KidNode);
 	}
 }
 
@@ -105,9 +91,3 @@ UAIScene* UAINode::GetScene()
 	return nullptr;
 }
 
-void UAINode::RegisterNewNode(aiNode* InNode, UAIScene* Scene, const aiMatrix4x4& ParentTransform)
-{
-	UAINode* Object = NewObject<UAINode>(this, UAINode::StaticClass(), NAME_None, RF_Transient);
-	Object->Setup(InNode, Scene, ParentTransform);
-	OwnedNodes.Add(Object);
-}

--- a/Source/UE_Assimp/Private/AIScene.cpp
+++ b/Source/UE_Assimp/Private/AIScene.cpp
@@ -85,6 +85,10 @@ UAIScene* UAIScene::InternalConstructNewScene(UObject* Parent, const aiScene* Sc
             SceneObject->SceneScale = 1.0f;
             UE_LOG(LogAssimp, Warning, TEXT("No UnitScaleFactor in metadata."));
         }
+        if (SceneObject->SceneScale == 0.0f) {
+            SceneObject->SceneScale = 1.0f;
+            UE_LOG(LogAssimp, Warning, TEXT("Zero UnitScaleFactor replaced with 1.0."));
+        }
         UE_LOG(LogAssimp, Warning, TEXT("UnitScaleFactor: %g"), SceneObject->SceneScale);
 
         // The "parent" transform of the root node is an identity matrix.

--- a/Source/UE_Assimp/Private/AssimpFunctionLibrary.cpp
+++ b/Source/UE_Assimp/Private/AssimpFunctionLibrary.cpp
@@ -225,43 +225,49 @@ void UAssimpFunctionLibrary::ImportScenes(TArray<FString> InFilenames, UObject* 
 
 	for (FString FileName : InFilenames)
 	{
-		const struct aiScene* scene = aiImportFile(TCHAR_TO_UTF8(*FileName), Flags);
-
-
-		if (!scene)
-		{
-			UE_LOG(LogAssimp, Error, TEXT("Error importing scene in assimpfunction library "))
-		}
-		else
-		{
-			UAIScene* Object = UAIScene::InternalConstructNewScene(ParentObject, scene);
-			Object->FullFilePath=FileName;
+		UAIScene* Object = UAssimpFunctionLibrary::ImportScene(FileName, ParentObject, Flags);
+		if (Object != nullptr)
+                {
 			Scenes.Add(Object);
-		}
+                }
+	}
+}
+
+UAIScene* UAssimpFunctionLibrary::ImportScene(FString FileName, UObject* ParentObject, int Flags)
+{
+	Assimp::DefaultLogger::set(new UEAssimpStream());
+
+	const struct aiScene* scene = aiImportFile(TCHAR_TO_UTF8(*FileName), (unsigned int)Flags);
+
+	if (!scene)
+	{
+		UE_LOG(LogAssimp, Error, TEXT("Error importing scene in assimpfunction library "))
+		return nullptr;
+	}
+	else
+	{
+		UAIScene* Object = UAIScene::InternalConstructNewScene(ParentObject, scene);
+		Object->FullFilePath=FileName;
+		return Object;
 	}
 }
 
 FTransform UAssimpFunctionLibrary::aiMatToTransform(aiMatrix4x4 NodeTransform)
 {
-	aiVector3t<float> Scale, Position;
-	aiQuaterniont<float> Rotation;
-	NodeTransform.Decompose(Scale, Rotation, Position);
-	FRotator CorrectedRotation = FQuat(-Rotation.x, Rotation.z, Rotation.y, Rotation.w).Rotator();
-	CorrectedRotation.Yaw = -CorrectedRotation.Yaw;
-	const FVector CorrectedPosition = FVector(Position.x * 100, Position.z * 100, Position.y * 100);
+	FMatrix mtx;
+	FTransform Transform;
 
-
-	FTransform Transform(CorrectedRotation, CorrectedPosition, FVector(Scale.x, Scale.z, Scale.y));
-
-
-	if (Transform.GetScale3D().IsZero())
-	{
-		Transform.SetScale3D(FVector(1));
+	// Note that assimp matrix is transpose of Unreal matrix.
+	// (The compiler will efficiently unroll these loops.)
+	for (int j = 0; j < 4; ++j) {
+		for (int i = 0; i < 4; ++i) {
+			mtx.M[i][j] = NodeTransform[j][i];
+		}
 	}
+	Transform = FTransform(mtx);
+
 	return Transform;
 }
-
-
 
 
 FString UAssimpFunctionLibrary::GetBoneName(FAIBone Bone)

--- a/Source/UE_Assimp/Private/AssimpFunctionLibrary.cpp
+++ b/Source/UE_Assimp/Private/AssimpFunctionLibrary.cpp
@@ -219,13 +219,13 @@ bool UAssimpFunctionLibrary::FileDialogShared(bool bSave, const void* ParentWind
 
 
 void UAssimpFunctionLibrary::ImportScenes(TArray<FString> InFilenames, UObject* ParentObject,
-                                          TArray<UAIScene*>& Scenes, int Flags)
+                                          TArray<UAIScene*>& Scenes, int Flags, bool DisableAutoSpaceChange)
 {
 	Assimp::DefaultLogger::set(new UEAssimpStream());
 
 	for (FString FileName : InFilenames)
 	{
-		UAIScene* Object = UAssimpFunctionLibrary::ImportScene(FileName, ParentObject, Flags);
+		UAIScene* Object = UAssimpFunctionLibrary::ImportScene(FileName, ParentObject, Flags, DisableAutoSpaceChange);
 		if (Object != nullptr)
                 {
 			Scenes.Add(Object);
@@ -233,9 +233,13 @@ void UAssimpFunctionLibrary::ImportScenes(TArray<FString> InFilenames, UObject* 
 	}
 }
 
-UAIScene* UAssimpFunctionLibrary::ImportScene(FString FileName, UObject* ParentObject, int Flags)
+UAIScene* UAssimpFunctionLibrary::ImportScene(FString FileName, UObject* ParentObject, int Flags, bool DisableAutoSpaceChange)
 {
 	Assimp::DefaultLogger::set(new UEAssimpStream());
+
+        if (!DisableAutoSpaceChange) {
+           Flags |= aiProcess_MakeLeftHanded | aiProcessPreset_TargetRealtime_Quality;
+        }
 
 	const struct aiScene* scene = aiImportFile(TCHAR_TO_UTF8(*FileName), (unsigned int)Flags);
 
@@ -246,7 +250,7 @@ UAIScene* UAssimpFunctionLibrary::ImportScene(FString FileName, UObject* ParentO
 	}
 	else
 	{
-		UAIScene* Object = UAIScene::InternalConstructNewScene(ParentObject, scene);
+		UAIScene* Object = UAIScene::InternalConstructNewScene(ParentObject, scene, DisableAutoSpaceChange);
 		Object->FullFilePath=FileName;
 		return Object;
 	}

--- a/Source/UE_Assimp/Public/AIScene.h
+++ b/Source/UE_Assimp/Public/AIScene.h
@@ -26,6 +26,7 @@ class UE_ASSIMP_API UAIScene : public UObject
 public:
 	static UAIScene* InternalConstructNewScene(UObject* Parent, const aiScene* Scene);
 
+
 	/*WIP Function:
 	WIll spawn all meshes in most optimised fashion 
 	*/
@@ -54,6 +55,8 @@ public:
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category="Assimp|Scene")
 	const TArray<UAICamera*>& GetAllCameras() const;
 
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category="Assimp|Scene")
+	float GetUnitScaleFactor();
 
 	//Texture
 	//! Returns an embedded texture. if null then check path or texture is not embedded and must be imported using unreal default import texture function

--- a/Source/UE_Assimp/Public/AIScene.h
+++ b/Source/UE_Assimp/Public/AIScene.h
@@ -24,7 +24,7 @@ class UE_ASSIMP_API UAIScene : public UObject
 
 	//TODO Get Meta data 
 public:
-	static UAIScene* InternalConstructNewScene(UObject* Parent, const aiScene* Scene);
+	static UAIScene* InternalConstructNewScene(UObject* Parent, const aiScene* Scene, const bool DisableAutoSpaceChange);
 
 
 	/*WIP Function:

--- a/Source/UE_Assimp/Public/AssimpFunctionLibrary.h
+++ b/Source/UE_Assimp/Public/AssimpFunctionLibrary.h
@@ -49,10 +49,10 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 
 	//Flags: You can use post process nodes and use | (bitwise Or) between them to create any combination of flags. Also We recommend using preset flags. Flip UV flag is needed for correct urneal engine meshes
 	UFUNCTION(BlueprintCallable)
-	static void ImportScenes(TArray<FString> InFilenames, UObject* ParentObject, TArray<UAIScene*>& Scenes, int Flags);
+	static void ImportScenes(TArray<FString> InFilenames, UObject* ParentObject, TArray<UAIScene*>& Scenes, int Flags, bool DisableAutoSpaceChange);
 
 	UFUNCTION(BlueprintCallable)
-	static UAIScene* ImportScene(FString FileName, UObject* ParentObject, int Flags);
+	static UAIScene* ImportScene(FString FileName, UObject* ParentObject, int Flags, bool DisableAutoSpaceChange);
 
 	static FTransform aiMatToTransform(aiMatrix4x4 NodeTransform);
 

--- a/Source/UE_Assimp/Public/AssimpFunctionLibrary.h
+++ b/Source/UE_Assimp/Public/AssimpFunctionLibrary.h
@@ -50,6 +50,10 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	//Flags: You can use post process nodes and use | (bitwise Or) between them to create any combination of flags. Also We recommend using preset flags. Flip UV flag is needed for correct urneal engine meshes
 	UFUNCTION(BlueprintCallable)
 	static void ImportScenes(TArray<FString> InFilenames, UObject* ParentObject, TArray<UAIScene*>& Scenes, int Flags);
+
+	UFUNCTION(BlueprintCallable)
+	static UAIScene* ImportScene(FString FileName, UObject* ParentObject, int Flags);
+
 	static FTransform aiMatToTransform(aiMatrix4x4 NodeTransform);
 
 	//Apply normal map settings to imported textures
@@ -119,7 +123,7 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
 	static int PostProcess_CalcTangentSpace()
 	{
-		return 0x1;
+		return aiProcess_CalcTangentSpace;
 	}
 
 	// -------------------------------------------------------------------------
@@ -136,7 +140,7 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
 	static int PostProcess_JoinIdenticalVertices()
 	{
-		return 0x2;
+		return aiProcess_JoinIdenticalVertices;
 	}
 
 	// -------------------------------------------------------------------------
@@ -155,7 +159,10 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	 */
 
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_MakeLeftHanded() { return 0x4; }
+	static int PostProcess_MakeLeftHanded()
+        {
+		return aiProcess_MakeLeftHanded;
+        }
 
 	// -------------------------------------------------------------------------
 	/** <hr>Triangulates all faces of all meshes.
@@ -175,7 +182,7 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
 	static int PostProcess_Triangulate()
 	{
-		return 0x8;
+		return aiProcess_Triangulate;
 	}
 
 	// -------------------------------------------------------------------------
@@ -206,7 +213,7 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
 	static int PostProcess_RemoveComponent()
 	{
-		return 0x10;
+		return aiProcess_RemoveComponent;
 	}
 
 	// -------------------------------------------------------------------------
@@ -225,7 +232,7 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
 	static int AiPostProcess_GenNormals()
 	{
-		return 0x20;
+		return aiProcess_GenNormals;
 	}
 
 	// -------------------------------------------------------------------------
@@ -244,7 +251,10 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	* appearance.
 	*/
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_GenSmoothNormals() { return 0x40; }
+	static int PostProcess_GenSmoothNormals()
+	{
+		return aiProcess_GenSmoothNormals;
+	}
 
 	// -------------------------------------------------------------------------
 	/** <hr>Splits large meshes into smaller sub-meshes.
@@ -265,7 +275,7 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	*/
 	static int PostProcess_SplitLargeMeshes()
 	{
-		return 0x80;
+		return aiProcess_SplitLargeMeshes;
 	}
 
 	// -------------------------------------------------------------------------
@@ -293,7 +303,10 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	* range.
 	*/
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_PreTransformVertices() { return 0x100; }
+	static int PostProcess_PreTransformVertices()
+	{
+		return aiProcess_PreTransformVertices;
+	}
 
 	// -------------------------------------------------------------------------
 	/** <hr>Limits the number of bones simultaneously affecting a single vertex
@@ -310,7 +323,10 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	* step might be of interest to you.
 	*/
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_LimitBoneWeights() { return 0x200; }
+	static int PostProcess_LimitBoneWeights()
+	{
+		return aiProcess_LimitBoneWeights;
+	}
 
 	// -------------------------------------------------------------------------
 	/** <hr>Validates the imported scene data structure.
@@ -339,7 +355,10 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	 * compulsory, but recommended.
 	*/
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_ValidateDataStructure() { return 0x400; }
+	static int PostProcess_ValidateDataStructure()
+	{
+		return aiProcess_ValidateDataStructure;
+	}
 
 	// -------------------------------------------------------------------------
 	/** <hr>Reorders triangles for better vertex cache locality.
@@ -355,7 +374,10 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	 * importer property can be used to fine-tune the cache optimization.
 	 */
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_ImproveCacheLocality() { return 0x800; }
+	static int PostProcess_ImproveCacheLocality()
+	{
+		return aiProcess_ImproveCacheLocality;
+	}
 
 	// -------------------------------------------------------------------------
 	/** <hr>Searches for redundant/unreferenced materials and removes them.
@@ -377,7 +399,10 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	 * <tt>#AI_CONFIG_PP_RRM_EXCLUDE_LIST</tt> importer property.
 	 */
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_RemoveRedundantMaterials() { return 0x1000; }
+	static int PostProcess_RemoveRedundantMaterials()
+	{
+		return aiProcess_RemoveRedundantMaterials;
+	}
 
 	// -------------------------------------------------------------------------
 	/** <hr>This step tries to determine which meshes have normal vectors
@@ -392,7 +417,10 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	 * to enable this step, although the result is not always correct.
 	*/
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_FixInfacingNormals() { return 0x2000; }
+	static int PostProcess_FixInfacingNormals()
+	{
+		return aiProcess_FixInfacingNormals;
+	}
 
 
 	// -------------------------------------------------------------------------
@@ -403,9 +431,12 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	 * If you have multiple armatures on your models we strongly recommend enabling this
 	 * Instead of writing your own multi-root, multi-armature lookups we have done the
 	 * hard work for you :)
-   */
+	*/
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_PopulateArmatureData() { return 0x4000; }
+	static int PostProcess_PopulateArmatureData()
+	{
+		return aiProcess_PopulateArmatureData;
+	}
 
 	// -------------------------------------------------------------------------
 	/** <hr>This step splits meshes with more than one primitive type in
@@ -420,7 +451,10 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	 *  exclude lines and points, which are rarely used, from the import.
 	*/
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_SortByPType() { return 0x8000; }
+	static int PostProcess_SortByPType()
+	{
+		return aiProcess_SortByPType;
+	}
 
 	// -------------------------------------------------------------------------
 	/** <hr>This step searches all meshes for degenerate primitives and
@@ -464,7 +498,10 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	 * format specification and write them as degenerate triangles instead.
 	*/
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_FindDegenerates() { return 0x10000; }
+	static int PostProcess_FindDegenerates()
+	{
+		return aiProcess_FindDegenerates;
+	}
 
 	// -------------------------------------------------------------------------
 	/** <hr>This step searches all meshes for invalid data, such as zeroed
@@ -480,7 +517,10 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	 * the accuracy of the check for duplicate animation tracks.
 	*/
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_FindInvalidData() { return 0x20000; }
+	static int PostProcess_FindInvalidData()
+	{
+		return aiProcess_FindInvalidData;
+	}
 
 	// -------------------------------------------------------------------------
 	/** <hr>This step converts non-UV mappings (such as spherical or
@@ -498,7 +538,10 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	 * properly.
 	 */
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_GenUVCoords() { return 0x40000; }
+	static int PostProcess_GenUVCoords()
+	{
+		return aiProcess_GenUVCoords;
+	}
 
 	// -------------------------------------------------------------------------
 	/** <hr>This step applies per-texture UV transformations and bakes
@@ -516,7 +559,10 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	 * (homogeneous) transformation matrix.
 	*/
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_TransformUVCoords() { return 0x80000; }
+	static int PostProcess_TransformUVCoords()
+	{
+		return aiProcess_TransformUVCoords;
+	}
 
 	// -------------------------------------------------------------------------
 	/** <hr>This step searches for duplicate meshes and replaces them
@@ -532,7 +578,10 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	 *  planned for future versions.
 	 */
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_FindInstances() { return 0x100000; }
+	static int PostProcess_FindInstances()
+	{
+		return aiProcess_FindInstances;
+	}
 
 	// -------------------------------------------------------------------------
 	/** <hr>A post-processing step to reduce the number of meshes.
@@ -544,7 +593,10 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	 *  compatible with both #AiPostProcess_SplitLargeMeshes and #AiPostProcess_SortByPType.
 	*/
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_OptimizeMeshes() { return 0x200000; }
+	static int PostProcess_OptimizeMeshes()
+	{
+		return aiProcess_OptimizeMeshes;
+	}
 
 
 	// -------------------------------------------------------------------------
@@ -574,7 +626,10 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	 *  usually fixes them all and makes them renderable.
 	*/
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_OptimizeGraph() { return 0x400000; }
+	static int PostProcess_OptimizeGraph()
+	{
+		return aiProcess_OptimizeGraph;
+	}
 
 	// -------------------------------------------------------------------------
 	/** <hr>This step flips all UV coordinates along the y-axis and adjusts
@@ -595,7 +650,10 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	 * applications.
 	*/
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_FlipUVs() { return 0x800000; }
+	static int PostProcess_FlipUVs()
+	{
+		return aiProcess_FlipUVs;
+	}
 
 	// -------------------------------------------------------------------------
 	/** <hr>This step adjusts the output face winding order to be CW.
@@ -611,14 +669,20 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	 * @endcode
 	*/
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_FlipWindingOrder() { return 0x1000000; }
+	static int PostProcess_FlipWindingOrder()
+	{
+		return aiProcess_FlipWindingOrder;
+	}
 
 	// -------------------------------------------------------------------------
 	/** <hr>This step splits meshes with many bones into sub-meshes so that each
 	 * sub-mesh has fewer or as many bones as a given limit.
 	*/
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_SplitByBoneCount() { return 0x2000000; }
+	static int PostProcess_SplitByBoneCount()
+	{
+		return aiProcess_SplitByBoneCount;
+	}
 
 	// -------------------------------------------------------------------------
 	/** <hr>This step removes bones losslessly or according to some threshold.
@@ -634,7 +698,10 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	 *  only if all bones within the scene qualify for removal.
 	*/
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_Debone() { return 0x4000000; }
+	static int PostProcess_Debone()
+	{
+		return aiProcess_Debone;
+	}
 
 
 	// -------------------------------------------------------------------------
@@ -648,7 +715,10 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	*  Use <tt>#AI_CONFIG_GLOBAL_SCALE_FACTOR_KEY</tt> to setup the global scaling factor.
 	*/
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_GlobalScale() { return 0x8000000; }
+	static int PostProcess_GlobalScale()
+	{
+		return aiProcess_GlobalScale;
+	}
 
 	// -------------------------------------------------------------------------
 	/** <hr>A postprocessing step to embed of textures.
@@ -660,7 +730,10 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	 *  of the imported model. And if so, it uses that.
 	 */
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_EmbedTextures() { return 0x10000000; }
+	static int PostProcess_EmbedTextures()
+	{
+		return aiProcess_EmbedTextures;
+	}
 
 	// AiPostProcess_GenEntityMeshes = 0x100000,
 	// AiPostProcess_OptimizeAnimations = 0x200000
@@ -668,7 +741,10 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 
 
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_ForceGenNormals() { return 0x20000000; }
+	static int PostProcess_ForceGenNormals()
+	{
+		return aiProcess_ForceGenNormals;
+	}
 
 	// -------------------------------------------------------------------------
 	/** <hr>Drops normals for all faces of all meshes.
@@ -681,13 +757,19 @@ FileTypes					The type filters to show in the dialog. This string should be a "|
 	 * This process gives sense back to AiPostProcess_JoinIdenticalVertices
 	 */
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_DropNormals() { return 0x40000000; }
+	static int PostProcess_DropNormals()
+	{
+		return aiProcess_DropNormals;
+	}
 
 	// -------------------------------------------------------------------------
 	/**
 	 */
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Assimp|PostProcess")
-	static int PostProcess_GenBoundingBoxes() { return 0x80000000; }
+	static int PostProcess_GenBoundingBoxes()
+	{
+		return aiProcess_GenBoundingBoxes;
+	}
 
 
 	/** @def aiProcess_ConvertToLeftHanded

--- a/Source/UE_Assimp/Public/UE_Assimp.h
+++ b/Source/UE_Assimp/Public/UE_Assimp.h
@@ -5,8 +5,8 @@
 #include "assimp/Logger.hpp"
 #include "assimp/LogStream.hpp"
 #include "Modules/ModuleManager.h"
-#define ToVector(In) FVector(In.x, In.z, In.y)
-#define ToVectorCM(In) FVector(In.x*100, In.z*100, In.y*100)//convert Meters to cm
+#define ToVector(In) FVector(In.x, In.y, In.z)
+#define ToVectorCM(In) FVector(In.x*100, In.y*100, In.z*100) //convert Meters to cm (DEPRECATED)
 DECLARE_LOG_CATEGORY_EXTERN(LogAssimp, Log, All);
 
 


### PR DESCRIPTION
Removed code that tried to swap from right-handed y-up to left-handed z-up coordinate systems and that applied scale factors.

- Replaced calls to "ToVectorCM" with "ToVector".
- Set "ToVector" to standard x,y,z order.
- matrix transform conversion (aiMatToTransform) is now a simple transpose.

Added GetUnitScaleFactor blueprint method.

Users can adjust scale by applying Unit Scale Factor to the root component, and can rotate from y-up to z-up with a -90 x-rotation of root component.

Users can also apply Assimp global scale at load time with the Post Process Global Scale Factor flag, and use the "Convert to Left Handed" flag.

Moved mesh loading from UAINode::Setup to UAIScene::InternalConstructNewScene alongside materials, lights and cameras. (It wasn't ASync anyway.)

Calculation of "WorldTransform" was incorrect in a few places. It is now kicked off with an Identity matrix scaled by the UnitScaleFactor when running Setup on the root node.
(WorldTransform isn't really needed anymore, since users can build a tree and pull the world transform out of the tree on blueprint side. I've confirmed that they match.)

Added ImportScene (singular) for cases where users don't want to load multiple scenes at the same time.

Changed AssimpFunctionLibrary.h to use the macro definitions from the Assimp header, rather than the hex values. (In case assimp changes them.)
